### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/100monkeys-ai/aegis-orchestrator/security/code-scanning/3](https://github.com/100monkeys-ai/aegis-orchestrator/security/code-scanning/3)

In general, the fix is to add an explicit `permissions:` block either at the root of the workflow (applies to all jobs) or to each job individually, granting only the scopes actually required. This workflow only checks out code and runs Rust tooling/tests; it does not create or modify pull requests, issues, releases, or packages. The minimal reasonable scope is read access to repository contents so `actions/checkout` can function: `contents: read`.

The single best fix without changing functionality is to add a workflow-level `permissions:` block near the top of `.github/workflows/ci.yml` (after `name: CI` or after `on:`) with `contents: read`. This will apply to `check`, `fmt`, and `test` without needing per-job duplication, and it prevents GitHub from granting broader write permissions implicitly. No imports or external definitions are needed, since this is just YAML configuration.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

at the root level (aligned with `name:` and `on:`). For clarity, placing it between `on:` and `env:` is typical, but any root position is valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
