### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled allocation size

### DIFF
--- a/cli/src/daemon/server.rs
+++ b/cli/src/daemon/server.rs
@@ -2048,12 +2048,17 @@ struct ListExecutionsQuery {
     limit: Option<usize>,
 }
 
+const MAX_EXECUTION_LIST_LIMIT: usize = 1000;
+
 async fn list_executions_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(query): axum::extract::Query<ListExecutionsQuery>,
 ) -> Json<serde_json::Value> {
     let agent_id = query.agent_id.map(AgentId);
-    let limit = query.limit.unwrap_or(20);
+    let limit = query
+        .limit
+        .unwrap_or(20)
+        .min(MAX_EXECUTION_LIST_LIMIT);
 
     match state
         .execution_service


### PR DESCRIPTION
Potential fix for [https://github.com/100monkeys-ai/aegis-orchestrator/security/code-scanning/10](https://github.com/100monkeys-ai/aegis-orchestrator/security/code-scanning/10)

In general, the fix should enforce an upper bound on any user-provided value that can influence allocation size (such as a `limit` for listing resources) and reject or normalize requests that exceed that bound. This caps potential memory usage and prevents huge allocations or database result sets driven by untrusted input.

The best minimal fix here is to introduce a constant `MAX_EXECUTION_LIST_LIMIT` within this file and clamp or validate `query.limit` against it in `list_executions_handler`. We can keep the existing default of 20 while ensuring that any user-provided `limit` larger than the maximum is either rejected with an HTTP error or silently capped. To avoid changing the handler’s return type (currently `Json<serde_json::Value>` and not `IntoResponse`), the least invasive behavior is to cap the value: e.g., parse `limit` with `unwrap_or(20)` and then take `limit = limit.min(MAX_EXECUTION_LIST_LIMIT);`. This does not change the method signature or error-handling structure and avoids introducing new dependencies.

Concretely:
- Add a `const MAX_EXECUTION_LIST_LIMIT: usize = <reasonable number>;` near `ListExecutionsQuery` or near other configuration constants at the bottom of the file.
- In `list_executions_handler`, change the `limit` calculation at line 2056 from `let limit = query.limit.unwrap_or(20);` to something like:

```rust
let mut limit = query.limit.unwrap_or(20);
if limit == 0 {
    limit = 1;
}
let limit = limit.min(MAX_EXECUTION_LIST_LIMIT);
```

  or simply `let limit = query.limit.unwrap_or(20).min(MAX_EXECUTION_LIST_LIMIT);` if you are fine with `0` being passed downstream. This ensures that the downstream `execution_service.list_executions(agent_id, limit)` never receives an unbounded value derived from user input, satisfying the CodeQL concern without affecting the rest of the code.

No new imports or external methods are required; we only add a constant and adjust a local variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
